### PR TITLE
Update application/helpers/partial_helper.php

### DIFF
--- a/application/helpers/partial_helper.php
+++ b/application/helpers/partial_helper.php
@@ -4,7 +4,7 @@ function partial($name, $data, $loop = FALSE)
 {
 	$output = "";
 	
-	if (strpos('/', $name) === FALSE)
+	if (strpos($name, '/') === FALSE)
 	{
 		$name = get_instance()->router->directory . get_instance()->router->class . '/_' . $name;
 	}


### PR DESCRIPTION
Fixed strpos check to be strpos($haystack, $needle) rather than erroneous strpos($needle, $haystack).

I was wondering why the partial helper wouldn't load from a custom folder. This was why.
